### PR TITLE
review packetHandling

### DIFF
--- a/src/ChickenAPI/Packets/CharacterScreenPacketHandler.cs
+++ b/src/ChickenAPI/Packets/CharacterScreenPacketHandler.cs
@@ -5,13 +5,16 @@ using ChickenAPI.Game.Network;
 
 namespace ChickenAPI.Packets
 {
-    public class PacketHandlerMethodReference
+    /// <summary>
+    /// Packet that does not need to be ingame to be handled
+    /// </summary>
+    public class CharacterScreenPacketHandler
     {
         #region Instantiation
 
-        public PacketHandlerMethodReference(Action<IPacket, ISession> handlerMethod, Type packetBaseParameterType)
+        public CharacterScreenPacketHandler(Action<IPacket, ISession> handler, Type packetBaseParameterType)
         {
-            HandlerMethod = handlerMethod;
+            Handler = handler;
             PacketType = packetBaseParameterType;
             PacketHeader = PacketType.GetCustomAttributes(typeof(PacketHeaderAttribute), true).FirstOrDefault() as PacketHeaderAttribute;
             Identification = PacketHeader?.Identification;
@@ -26,8 +29,8 @@ namespace ChickenAPI.Packets
 
         #region Properties
 
-        public Action<IPacket, ISession> HandlerMethod { get; }
-        public PacketHeaderAttribute PacketHeader { get; set; }
+        public Action<IPacket, ISession> Handler { get; }
+        public PacketHeaderAttribute PacketHeader { get; }
         public AuthorityType Authority { get; }
         public string Identification { get; }
         public Type PacketType { get; }

--- a/src/ChickenAPI/Packets/GamePacketHandler.cs
+++ b/src/ChickenAPI/Packets/GamePacketHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using ChickenAPI.ECS.Entities;
+using ChickenAPI.Enums;
+
+namespace ChickenAPI.Packets
+{
+    /// <summary>
+    /// Game Packets only
+    /// </summary>
+    public class GamePacketHandler
+    {
+        public GamePacketHandler(Action<IPacket, IPlayerEntity> handler, Type packetType)
+        {
+            HandlerMethod = handler;
+
+            PacketType = packetType;
+            PacketHeader = PacketType.GetCustomAttributes(typeof(PacketHeaderAttribute), true).FirstOrDefault() as PacketHeaderAttribute;
+            Identification = PacketHeader?.Identification;
+            Authority = PacketHeader?.Authority ?? AuthorityType.User;
+        }
+
+
+        public Action<IPacket, IPlayerEntity> HandlerMethod { get; }
+        public PacketHeaderAttribute PacketHeader { get; set; }
+        public AuthorityType Authority { get; }
+        public string Identification { get; }
+        public Type PacketType { get; }
+    }
+}

--- a/src/ChickenAPI/Packets/IPacketHandler.cs
+++ b/src/ChickenAPI/Packets/IPacketHandler.cs
@@ -1,12 +1,33 @@
 ﻿using System;
+using ChickenAPI.ECS.Entities;
 using ChickenAPI.Game.Network;
 
 namespace ChickenAPI.Packets
 {
     public interface IPacketHandler
     {
-        void Register(PacketHandlerMethodReference method);
-        PacketHandlerMethodReference GetPacketHandlerMethodReference(string header);
-        void Handle(IPacket packetBase, ISession session, Type type);
+        void Register(CharacterScreenPacketHandler method);
+        void Register(GamePacketHandler method);
+
+        void UnregisterCharacterScreenHandler(Type packetType);
+        void UnregisterCharacterScreenHandler(string header);
+
+        void UnregisterGameHandler(Type packetType);
+        void UnregisterGameHandler(string header);
+
+        CharacterScreenPacketHandler GetCharacterScreenPacketHandler(string header);
+        GamePacketHandler GetGamePacketHandler(string header);
+
+        /// <summary>
+        /// Handle the CharacterScreen packet
+        /// </summary>
+        /// <param name="handlingInfo"></param>
+        void Handle((IPacket, ISession) handlingInfo);
+
+        /// <summary>
+        /// Handle the Game packet
+        /// </summary>
+        /// <param name="handlingInfo"></param>
+        void Handle((IPacket, IPlayerEntity) handlingInfo);
     }
 }


### PR DESCRIPTION
I separated CharacterScreen packets and Game packets because :

CharacterScreen packets does not need a player to be instanciated ingame to be accessed while Game Packets needs a player to have a character instanciated to be sent by client.


It's a V1, I think we will probably look forward for a better review once ChickenAPI will be more mature :)